### PR TITLE
Changed to make Exception throws fatal, not PE.

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
@@ -938,8 +938,8 @@ class TestCLIParsing {
     )
     runCLI(args"parse -s $schema") { cli =>
       cli.sendLine("0", inputDone = true)
-      cli.expectErr("Parse Error: bad input stream")
-    }(ExitCode.ParseError)
+      cli.expectErr("bad input stream")
+    }(ExitCode.BugFound)
   }
 
   @Test def test_CLI_util_expectException(): Unit = {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.core.layers
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import scala.util.Random
+
+import org.apache.daffodil.core.util.TestUtils
+import org.apache.daffodil.lib.Implicits.intercept
+import org.apache.daffodil.lib.util._
+import org.apache.daffodil.lib.xml.XMLUtils
+import org.apache.daffodil.runtime1.processors.parsers.ParseError
+
+import org.apache.commons.io.IOUtils
+import org.junit.Test
+
+class TestGzipErrors {
+
+  val example = XMLUtils.EXAMPLE_NAMESPACE
+
+  val text =
+    """This is just some made up text that is intended to be
+a few lines long. If this had been real text, it would not have been quite
+so boring to read. Use of famous quotes or song lyrics or anything like that
+introduces copyright notice issues, so it is easier to simply make up
+a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", " ")
+
+  val GZIPLayer1Schema =
+    SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <xs:import namespace="urn:org.apache.daffodil.layers.gzip"
+                     schemaLocation="/org/apache/daffodil/layers/xsd/gzipLayer.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat" representation="binary"/>,
+      <xs:element name="root">
+        <xs:complexType>
+          <xs:choice>
+            <xs:element name="e1" dfdl:lengthKind="implicit"
+                        xmlns:gz="urn:org.apache.daffodil.layers.gzip">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="len" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="4"
+                              dfdl:outputValueCalc="{ dfdl:contentLength(../x1/data, 'bytes') }"/>
+                  <xs:element name="x1" dfdl:lengthKind="explicit" dfdl:length="{ ../len }">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="data">
+                          <xs:complexType>
+                            <xs:sequence dfdlx:layer="gz:gzip">
+                              <xs:element name="s1" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="s2" type="xs:string" dfdl:lengthKind="delimited"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="hex" type="xs:hexBinary" dfdl:lengthKind="delimited" dfdl:encoding="iso-8859-1"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>,
+      elementFormDefault = "unqualified",
+    )
+
+  def makeGZIPData(text: String) = {
+    val baos = new ByteArrayOutputStream()
+    val gzos = new java.util.zip.GZIPOutputStream(baos)
+    IOUtils.write(text, gzos, StandardCharsets.UTF_8)
+    gzos.close()
+    val data = baos.toByteArray()
+    // Java 16+ sets the 9th byte to 0xFF, but previous Java versions set the
+    // value to 0x00. Daffodil always unparses with 0xFF regardless of Java
+    // version, so force the gzip data to 0xFF to make sure tests round trip
+    data(9) = 0xff.toByte
+    data
+  }
+
+  def makeGZIPLayer1Data() = {
+    val gzipData = makeGZIPData(text)
+    val dataLength = gzipData.length
+    val baos = new ByteArrayOutputStream()
+    val dos = new java.io.DataOutputStream(baos)
+    dos.writeInt(dataLength)
+    dos.write(gzipData)
+    dos.write("afterGzip".getBytes(StandardCharsets.UTF_8))
+    dos.close()
+    val data = baos.toByteArray()
+    (data, dataLength)
+  }
+
+  @Test def testGZIPLayerOk1(): Unit = {
+    val sch = GZIPLayer1Schema
+    val (data, _) = makeGZIPLayer1Data()
+    val infoset =
+      <ex:root xmlns:ex={example}>
+      <e1>
+        <len>{212}</len>
+        <x1>
+        <data>
+          <s1>{text}</s1>
+        </data>
+      </x1>
+        <s2>afterGzip</s2>
+      </e1>
+    </ex:root>
+    val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
+    TestUtils.assertEqualsXMLElements(infoset, actual)
+  }
+
+  @Test def testGZIPLayerErr1(): Unit = {
+    val sch = GZIPLayer1Schema
+    val (data, _) = makeGZIPLayer1Data()
+    // clobber half the data
+    ((data.length / 2) to data.length - 1).foreach { i => data(i) = 0 }
+    // This causes the gzip input stream to throw an IOException
+    val infoset =
+      <ex:root xmlns:ex={example}>
+        <hex xmlns=""><![CDATA[000000D41F8B08000000000000FF4D904176C3200C44AF3207C8F33DBA6F0F40CCD85683918B44D3DC3EC2C9A2EFB1013EF3357C6E6288F5DDCD61BA137BCA443FE0FC73F8967C5C4B75D6CC0C575C8984857714A93414ADEB848F25D800B794036045632A67C605E2B86B2F19553D800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]]></hex>
+      </ex:root>
+    val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
+    TestUtils.assertEqualsXMLElements(infoset, actual)
+  }
+
+  @Test def testGZIPLayerErr2(): Unit = {
+    val sch = GZIPLayer1Schema
+    val (data, _) = makeGZIPLayer1Data()
+    // clobber last 10% of the data with 0xFF bytes.
+    ((data.length - (data.length / 10)) to data.length - 1).foreach { i => data(i) = -1 }
+    // This causes the gzip input stream to throw an IOException
+    val infoset =
+      <ex:root xmlns:ex={example}>
+        <hex xmlns=""><![CDATA[000000D41F8B08000000000000FF4D904176C3200C44AF3207C8F33DBA6F0F40CCD85683918B44D3DC3EC2C9A2EFB1013EF3357C6E6288F5DDCD61BA137BCA443FE0FC73F8967C5C4B75D6CC0C575C8984857714A93414ADEB848F25D800B794036045632A67C605E2B86B2F19553D805FBE889F2ECE70E2AA4DEA3AA2E3519EF065842E58D2AEDD02530F8DB640832A8F26F3B94DF511CA712437BE27ADDE34F739F8598F20D7CD875566460BEBB4CB10CAD989C9846D684DF6A33CA2F9ED6CFEBF5DCC7168C4169ABDBEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF]]></hex>
+      </ex:root>
+    val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
+    TestUtils.assertEqualsXMLElements(infoset, actual)
+  }
+
+  val GZIPLayerErrSchema =
+    SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <xs:import namespace="urn:org.apache.daffodil.layers.gzip"
+                     schemaLocation="/org/apache/daffodil/layers/xsd/gzipLayer.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat" representation="binary"/>,
+      <xs:element name="root">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e1" dfdl:lengthKind="implicit"
+                        xmlns:gz="urn:org.apache.daffodil.layers.gzip">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="len" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"
+                              dfdl:outputValueCalc="{ dfdl:contentLength(../x1/data, 'bytes') }"/>
+                  <xs:element name="x1" dfdl:lengthKind="explicit" dfdl:length="{ ../len }">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="data">
+                          <xs:complexType>
+                            <xs:sequence dfdlx:layer="gz:gzip">
+                              <xs:element name="s1" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="s2" type="xs:string" dfdl:lengthKind="delimited"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>,
+      elementFormDefault = "unqualified",
+    )
+
+  /**
+   * These are parse errors due to IOExceptions that occur.
+   */
+  val excludes = Seq(
+    "EOFException",
+    "Corrupt GZIP trailer",
+    "Unexpected end of ZLIB",
+    "invalid distance too far back",
+    "Not in GZIP format",
+    "invalid literal/lengths set",
+    "invalid bit length repeat",
+    "invalid code lengths set",
+    "invalid code -- missing end-of-block",
+    "invalid distances set",
+    "Unsupported compression method",
+    "Insufficient bits in data",
+    "too many length or distance symbols",
+    "invalid stored block lengths",
+    "invalid block type",
+  )
+
+  @Test def testGZIPLayerFuzz1(): Unit = fuzz1(2) // fuzz1(1000)
+
+  def fuzz1(nTrials: Int): Unit = {
+    val seed = 987654321
+    val sch = GZIPLayerErrSchema
+    val r = new Random(seed)
+    (1 to nTrials).foreach { i =>
+      val (data, _) = makeGZIPLayer1Data()
+      // clobber last section of the data (up to 95% of it) with random bytes.
+      ((data.length - (data.length / (r.nextInt(19) + 1))) to (data.length - 1)).foreach { i =>
+        data(i) = (r.nextInt(256) & 0xff).toByte
+      }
+      val e = intercept[ParseError] {
+        TestUtils.testBinary(sch, data, areTracing = false)
+      }
+      val m = TestUtils.getAMessage(e)
+      if (excludes.forall(ex => !m.contains(ex)))
+        println(TestUtils.getAMessage(e))
+    }
+  }
+
+  @Test def testGZIPLayerFuzz2(): Unit = fuzz2(2) // fuzz2(1000)
+
+  def fuzz2(nTrials: Int): Unit = {
+    val expected = <root xmlns="http://example.com">
+      <e1 xmlns="">
+        <len>212</len> <x1>
+        <data>
+          <s1>This is just some made up text that is intended to be a few lines long. If this had been real text, it would not have been quite so boring to read. Use of famous quotes or song lyrics or anything like that introduces copyright notice issues, so it is easier to simply make up a few lines of pointless text like this.</s1>
+        </data>
+      </x1> <s2>afterGzip</s2>
+      </e1>
+    </root>
+    val seed = 123456789
+    val sch = GZIPLayerErrSchema
+    val r = new Random(seed)
+    var index = 0
+    var current: Byte = 0
+    var newValue: Byte = 0
+    (1 to nTrials).foreach { i =>
+      print(i + ".")
+      val (data, len) = makeGZIPLayer1Data()
+      // clobber one randomly chosen byte with a random byte.
+      index =
+        math.max(4, r.nextInt(len)) // at least 4 bytes in so we don't hammer the length field.
+      current = data(index)
+      newValue = current
+      // make sure they are different so we're definitely changing a byte value
+      while (current == newValue) {
+        newValue = ((current ^ r.nextInt(256)) & 0xff).toByte
+      }
+      data(index) = newValue
+      val (pr, node) =
+        try {
+          TestUtils.testBinary(sch, data, areTracing = false)
+        } catch {
+          case e: ParseError => {
+            val m = TestUtils.getAMessage(e)
+            if (excludes.forall(ex => !m.contains(ex))) {
+              println(TestUtils.getAMessage(e))
+            }
+            (null, null)
+          }
+        }
+      if (pr ne null) {
+        TestUtils.assertEqualsXMLElements(expected, node)
+        // println(s"parsed without error despite byte at index $index modified from $current to $newValue.\n Infoset: ${node.toString()}")
+      }
+    }
+  }
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/util/FuzzData.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/util/FuzzData.scala
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.core.util
+
+import java.io.ByteArrayInputStream
+import scala.collection.mutable
+import scala.util.Random
+import scala.xml.Elem
+import scala.xml.Node
+import org.apache.daffodil.core.util.TestUtils.getAMessage
+import org.apache.daffodil.lib.exceptions.Assert
+import org.apache.daffodil.lib.xml.XMLUtils.XMLDifferenceException
+import org.apache.daffodil.runtime1.processors.parsers.ParseError
+import org.junit.Assert.fail
+
+/**
+ * Utility base class to support fuzz testing. Given a piece of data,
+ * it fuzzes it (without modifying the original data) each time next() is
+ * called.
+ *
+ * The kind of fuzzing, what region within the data, how much data (run length),
+ * and what it is overwritten with, is determined by the parameters to
+ * the constructor, and the implementations of the runLength and fuzzOneByte
+ * methods.
+ * @param data a byte array of data to created fuzzed instances of.
+ * @param offset where in the data to start the fuzzed region
+ * @param endOffset where, measured back from the end, we want to protect from fuzzing
+ * @param seed random number generator seed. Choosing different values for this
+ *             will produce different fuzzed data, but it should be perfectly
+ *             repeatable. Defaults to a specific value so that tests will be
+ *             repeatable.
+ */
+abstract class FuzzData(
+  val data: Array[Byte],
+  offset: Int, // allows you not to clobber a prefix of the data
+  endOffset: Int, // number of bytes at the end to not clobber
+  seed: Int = 1, // specify to get varied, but repeatable results
+) extends Iterator[Array[Byte]] {
+
+  protected val r = new Random(seed)
+  protected val dataLen = data.length
+  private val originalData = data.clone()
+
+  /**
+   * Override this to generate a random run length, or to specify
+   * a specific run length. Must be > 0.
+   * @return an integer greater than 0, and less than than
+   *         the size of the region to fuzz.
+   */
+  def runLength: Int
+
+  override def hasNext() = true // we can keep fuzzing forever
+
+  override def next(): Array[Byte] = {
+    val data = originalData.clone()
+    val limit = dataLen - endOffset
+    val regionLen = limit - offset
+    val runLen = runLength
+    val regionRunLocations = regionLen - runLen
+    val startOfRun = r.nextInt(regionRunLocations)
+    (startOfRun to (startOfRun + runLen)).foreach { i =>
+      fuzzOneByte(data, i)
+    }
+    data
+  }
+
+  /**
+   * Modifies one byte of the data array at the given position
+   * @param data the byte array to modify
+   * @param i zero-based position of the byte to modify
+   */
+  def fuzzOneByte(data: Array[Byte], i: Int): Unit
+}
+
+class FuzzZeroBits(data: Array[Byte], offset: Int, endOffset: Int)
+  extends FuzzData(data, offset, endOffset) {
+
+  override def runLength: Int = r.nextInt(dataLen - (offset + endOffset) - 1)
+
+  override def fuzzOneByte(data: Array[Byte], i: Int): Unit = data(i) = 0
+}
+
+class FuzzOneBits(data: Array[Byte], offset: Int, endOffset: Int)
+  extends FuzzData(data, offset, endOffset) {
+
+  override def runLength: Int = r.nextInt(dataLen - (offset + endOffset) - 1)
+
+  override def fuzzOneByte(data: Array[Byte], i: Int): Unit = data(i) = 0xff.toByte
+}
+
+class FuzzRandomSingleByte(data: Array[Byte], offset: Int, endOffset: Int)
+  extends FuzzData(data, offset, endOffset) {
+
+  override def runLength: Int = 1
+
+  override def fuzzOneByte(data: Array[Byte], i: Int): Unit = {
+    var current: Byte = data(i)
+    var newValue: Byte = current
+    // make sure they are different so we're definitely changing a byte value
+    while (current == newValue) {
+      newValue = ((current ^ r.nextInt(256)) & 0xff).toByte
+    }
+    data(i) = newValue
+  }
+}
+
+class FuzzRandomByteRuns(data: Array[Byte], offset: Int, endOffset: Int)
+  extends FuzzRandomSingleByte(data, offset, endOffset) {
+  override def runLength = r.nextInt(dataLen - (offset + endOffset) - 1)
+}
+
+/**
+ * Parses fuzzed data with a DFDL schema. Gathers unexpected throw classes
+ * (things thrown other than parse errors), and also gathers unexpected
+ * successes where the fuzzed data did not cause the parse to fail.
+ * @param sch - scala.xml.Node which is the schema to test
+ * @param data - data which will be fuzzed to create many variations
+ * @param expected - expected XML if the data parses successfully
+ * @param fuzzer - a FuzzData object
+ */
+class FuzzParseTester(
+  sch: Elem,
+  data: Array[Byte],
+  expected: Elem,
+  fuzzer: FuzzData,
+) {
+
+  private val p = TestUtils.compileSchema(sch)
+
+  val unexpectedThrowClasses = new mutable.HashSet[Class[_ <: Throwable]]()
+
+  val okParses = new mutable.HashSet[(Node, Array[Byte], XMLDifferenceException)]
+
+  protected def handleParseError(p: ParseError, testData: Array[Byte], i: Int) = {
+    // do nothing by default
+  }
+
+  protected def handleThrow(t: Throwable): Unit = {
+    unexpectedThrowClasses += t.getClass
+  }
+
+  protected def handleUnexpectedSuccess(
+    actual: Node,
+    testData: Array[Byte],
+    diff: XMLDifferenceException,
+  ): Unit = {
+    // we didn't get a throw from this fuzzed data
+    // but the XML output was not what was expected either
+    // save up the first N such.
+    if (okParses.size <= 10)
+      okParses += ((actual, testData, diff)) // extra parens because of varargs stuff ??
+  }
+
+  def run(nTrials: Int): Unit = {
+    Assert.usage(nTrials >= 1)
+    (1 to nTrials).foreach { i =>
+      val testData = fuzzer.next()
+      val bais = new ByteArrayInputStream(testData)
+      val (pr, node) =
+        try {
+          TestUtils.runDataProcessorOnInputStream(p, bais, areTracing = false)
+        } catch {
+          case p: ParseError => {
+            handleParseError(p, testData, i)
+            (null, null)
+          }
+          case t: Throwable => {
+            handleThrow(t)
+            (null, null)
+          }
+        }
+      if (pr ne null) {
+        try {
+          TestUtils.assertEqualsXMLElements(expected, node)
+        } catch {
+          case e: XMLDifferenceException =>
+            handleUnexpectedSuccess(node, testData, e)
+        }
+      }
+    }
+  }
+
+}
+
+class LayerParseTester(
+  sch: Elem,
+  data: Array[Byte],
+  expected: Elem,
+  fuzzer: FuzzData,
+  excludes: Seq[String],
+) extends FuzzParseTester(sch, data, expected, fuzzer) {
+
+  var shouldFail = false
+
+  override def handleParseError(p: ParseError, data: Array[Byte], nth: Int): Unit = {
+    val msg = getAMessage(p)
+    if (excludes.exists { msg.contains(_) }) {
+      // we know about this one
+    } else {
+      // new parse error type
+      println(s"trial $nth produced $p")
+      shouldFail = true
+    }
+  }
+
+  override def run(nTrials: Int) = {
+    super.run(nTrials)
+    if (unexpectedThrowClasses.size > 0) {
+      unexpectedThrowClasses.foreach { c =>
+        println(s"Class ${c.getSimpleName} was thrown")
+        shouldFail = true
+      }
+    }
+    if (okParses.size > 0)
+      println(s"Parse succeeded on fuzzed data ${okParses.size} times.")
+    if (shouldFail)
+      fail("errors were found")
+  }
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -326,14 +326,16 @@ object TestUtils {
    * @return
    */
   def getAMessage(cause: Throwable): String = {
+    val n1 = Misc.getNameFromClass(cause)
     val m = cause.getMessage
     val c = cause.getCause
-    (m, c) match {
+    val s = (m, c) match {
       case (null, null) => Misc.getNameFromClass(cause)
       case (null, c) => getAMessage(c)
       case (m, null) => m
       case (m, c) => m + " " + getAMessage(c)
     }
+    n1 + s"($s)"
   }
 }
 

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/BoundaryMarkLayer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/BoundaryMarkLayer.scala
@@ -19,10 +19,12 @@ package org.apache.daffodil.layers.runtime1
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.charset.Charset
+import java.nio.charset.IllegalCharsetNameException
+import java.nio.charset.UnsupportedCharsetException
 
 import org.apache.daffodil.io.BoundaryMarkInsertingJavaOutputStream
 import org.apache.daffodil.io.BoundaryMarkLimitingInputStream
-import org.apache.daffodil.lib.exceptions.Assert
+import org.apache.daffodil.runtime1.layers.ScalaLayerHelper
 import org.apache.daffodil.runtime1.layers.api.Layer
 
 /**
@@ -49,14 +51,21 @@ import org.apache.daffodil.runtime1.layers.api.Layer
  * This layer defines two DFDL variables which provide required parameters.
  */
 final class BoundaryMarkLayer
-  extends Layer("boundaryMark", "urn:org.apache.daffodil.layers.boundaryMark") {
+  extends Layer("boundaryMark", "urn:org.apache.daffodil.layers.boundaryMark")
+  with ScalaLayerHelper {
 
   private var boundaryMark: String = _
-  private var layerEncoding: String = _
+  private var charset: Charset = _
 
   private val maxBoundaryMarkLength: Int = Short.MaxValue
 
+  // initialization. These exceptions get converted to processing errors
+  setProcessingErrorException(classOf[IllegalCharsetNameException])
+  setProcessingErrorException(classOf[UnsupportedCharsetException])
+
   /**
+   * Provides the layer's parameter variables to the layer.
+   *
    * @param boundaryMark  a string which is the boundary marker. Searching for this string is
    *                      done without any notion of escaping. When parsing the data in the
    *                      layer is up to but not including that of the boundary mark string,
@@ -72,26 +81,13 @@ final class BoundaryMarkLayer
   ): Unit = {
     this.boundaryMark = boundaryMark
     if (boundaryMark.isEmpty)
-      processingError("The boundaryMark variable value may not be empty string.")
+      procError("The boundaryMark variable value may not be empty string.")
     if (boundaryMark.length > maxBoundaryMarkLength)
-      processingError(
+      procError(
         s"The boundaryMark string length may not be greater than the limit: $maxBoundaryMarkLength",
       )
-    this.layerEncoding = layerEncoding
+    this.charset = Charset.forName(layerEncoding)
   }
-
-  private lazy val charset =
-    try {
-      Charset.forName(layerEncoding)
-    } catch {
-      // the runtime exceptions thrown by forName want to be
-      // caught and turned into regular Exceptions.
-      // That's not generally true, but it is for encodings/charsets.
-      case re: RuntimeException => {
-        processingError(re) // throw new Exception(re)
-        Assert.impossible("unreachable")
-      }
-    }
 
   override def wrapLayerInput(jis: InputStream): InputStream = {
     new BoundaryMarkLimitingInputStream(jis, boundaryMark, charset)

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/BoundaryMarkLayer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/BoundaryMarkLayer.scala
@@ -22,6 +22,7 @@ import java.nio.charset.Charset
 
 import org.apache.daffodil.io.BoundaryMarkInsertingJavaOutputStream
 import org.apache.daffodil.io.BoundaryMarkLimitingInputStream
+import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.runtime1.layers.api.Layer
 
 /**
@@ -86,7 +87,10 @@ final class BoundaryMarkLayer
       // the runtime exceptions thrown by forName want to be
       // caught and turned into regular Exceptions.
       // That's not generally true, but it is for encodings/charsets.
-      case re: RuntimeException => throw new Exception(re)
+      case re: RuntimeException => {
+        processingError(re) // throw new Exception(re)
+        Assert.impossible("unreachable")
+      }
     }
 
   override def wrapLayerInput(jis: InputStream): InputStream = {

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/GZipLayer.java
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/runtime1/GZipLayer.java
@@ -51,19 +51,8 @@ public final class GZipLayer extends Layer {
 
   public GZipLayer() {
     super("gzip", "urn:org.apache.daffodil.layers.gzip");
-
-    // we need a layer throw handler to convert any IOExceptions into
-    // processing errors so they can backtrack (i.e., are not fatal)
-    setLayerThrowHandler(new LayerThrowHandler() {
-      @Override
-      public void handleThrow(Throwable t) {
-        // Fuzz testing shows gzip does a good job converting all sorts of parse errors
-        // into IOException. If there were other kinds of exceptions thrown, we could also
-        // catch them here.
-        if (t instanceof IOException)
-          processingError(t);
-      }
-    });
+    // convert IOExceptions to Processing Errors
+    setProcessingErrorException(IOException.class);
   }
 
   @Override

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
@@ -21,7 +21,6 @@ import org.apache.daffodil.lib.exceptions.UnsuppressableException
 import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
 import org.apache.daffodil.runtime1.layers.LayerDriver
 import org.apache.daffodil.runtime1.layers.LayerFatalException
-import org.apache.daffodil.runtime1.layers.LayerUnexpectedException
 import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 import org.apache.daffodil.runtime1.processors.unparsers._
 
@@ -109,7 +108,8 @@ class LayeredSequenceUnparser(
       case sde: RuntimeSchemaDefinitionError =>
         throw sde
       case e: Exception =>
-        state.toss(state.toProcessingError(new LayerUnexpectedException(e)))
+        // state.toss(state.toProcessingError(new LayerUnexpectedException(e)))
+        throw new LayerFatalException(e)
     } finally {
       // reset the state so subsequent unparsers write to the following DOS
       state.dataOutputStream = layerFollowingDOS

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/ScalaLayerHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/ScalaLayerHelper.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.runtime1.layers
+
+import org.apache.daffodil.runtime1.layers.api.Layer
+
+/**
+ * The Layer API is defined in Java. This gives the things that throw more
+ * scala-flavored signatures (returns Nothing, not Unit)
+ */
+trait ScalaLayerHelper { self: Layer =>
+
+  def procError(e: Exception): Nothing = processingError(e).asInstanceOf[Nothing]
+  def procError(msg: String): Nothing = processingError(msg).asInstanceOf[Nothing]
+
+  def runtimeSDE(e: Exception): Nothing = runtimeSchemaDefinitionError(e).asInstanceOf[Nothing]
+  def runtimeSDE(msg: String): Nothing = runtimeSchemaDefinitionError(msg).asInstanceOf[Nothing]
+
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/api/Layer.java
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/api/Layer.java
@@ -19,7 +19,6 @@ package org.apache.daffodil.runtime1.layers.api;
 import org.apache.daffodil.runtime1.layers.LayerRuntime;
 import org.apache.daffodil.runtime1.layers.LayerUtils;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -167,7 +166,7 @@ public abstract class Layer {
    * @param jis The input stream to be wrapped.
    * @return An input stream with the layer wrapped around it.
    */
-  public abstract InputStream wrapLayerInput(InputStream jis);
+  public abstract InputStream wrapLayerInput(InputStream jis) throws Exception;
 
   /**
    * Wraps a layer output interpreter around an output stream, using the provided LayerRuntimeFoo for runtime information and stateful services.
@@ -175,6 +174,31 @@ public abstract class Layer {
    * @param jos The output stream to be wrapped.
    * @return An output stream with the layer wrapped around it.
    */
-  public abstract OutputStream wrapLayerOutput(OutputStream jos);
+  public abstract OutputStream wrapLayerOutput(OutputStream jos) throws Exception;
+
+  private LayerThrowHandler lth = null;
+
+  public static interface LayerThrowHandler {
+    public void handleThrow(Throwable t);
+  }
+
+  /**
+   * If you set a layer throw handler, then if the layer code throws
+   * anything, the handler is invoked and can convert specific kinds of
+   * exceptions into processing errors or runtime SDEs.
+   *
+   * If the handler does not throw or call processingError or
+   * runtimeSchemaDefinitionError, then the throw is treated as
+   * if there was no handler, and propagates generally as a fatal error.
+   *
+   * @param lth the throw handler
+   */
+  public final void setLayerThrowHandler(LayerThrowHandler lth) {
+    this.lth = lth;
+  }
+
+  public final LayerThrowHandler getLayerThrowHandler() {
+    return this.lth;
+  }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
@@ -22,7 +22,6 @@ import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
 import org.apache.daffodil.runtime1.layers.LayerDriver
 import org.apache.daffodil.runtime1.layers.LayerFatalException
 import org.apache.daffodil.runtime1.layers.LayerProcessingException
-import org.apache.daffodil.runtime1.layers.LayerUnexpectedException
 import org.apache.daffodil.runtime1.processors.ProcessingError
 import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 
@@ -69,7 +68,8 @@ class LayeredSequenceParser(
       case le: LayerProcessingException =>
         state.toss(state.toProcessingError(le))
       case e: Exception =>
-        state.toss(state.toProcessingError(new LayerUnexpectedException(e)))
+        throw new LayerFatalException(e)
+      // state.toss(state.toProcessingError(new LayerUnexpectedException(e)))
     }
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
@@ -17,12 +17,7 @@
 
 package org.apache.daffodil.runtime1.processors.parsers
 
-import org.apache.daffodil.lib.exceptions.UnsuppressableException
-import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
 import org.apache.daffodil.runtime1.layers.LayerDriver
-import org.apache.daffodil.runtime1.layers.LayerFatalException
-import org.apache.daffodil.runtime1.layers.LayerProcessingException
-import org.apache.daffodil.runtime1.processors.ProcessingError
 import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 
 class LayeredSequenceParser(
@@ -33,9 +28,12 @@ class LayeredSequenceParser(
 
   override def parse(state: PState): Unit = {
 
+    var layerDriver: LayerDriver = null
     val savedDIS = state.dataInputStream
     try {
-      val layerDriver = LayerDriver(state, rd.layerRuntimeData)
+      layerDriver = LayerDriver(state, rd.layerRuntimeData)
+      layerDriver.init() // could fail if user's method causes errors
+
       val isAligned = savedDIS.align(layerDriver.mandatoryLayerAlignmentInBits, state)
       if (!isAligned)
         PE(
@@ -57,19 +55,8 @@ class LayeredSequenceParser(
         }
       }
     } catch {
-      case u: UnsuppressableException => throw u
-      case lre: LayerFatalException =>
-        throw lre
-      case re: RuntimeException =>
-        throw new LayerFatalException(re)
-      case pe: ProcessingError =>
-        throw pe
-      case rsde: RuntimeSchemaDefinitionError => throw rsde
-      case le: LayerProcessingException =>
-        state.toss(state.toProcessingError(le))
-      case e: Exception =>
-        throw new LayerFatalException(e)
-      // state.toss(state.toProcessingError(new LayerUnexpectedException(e)))
+      case t: Throwable if layerDriver ne null => layerDriver.handleThrowable(t)
+      case t: Throwable => LayerDriver.handleThrowableWithoutLayer(t)
     }
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/AISPayloadArmoringLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/AISPayloadArmoringLayer.scala
@@ -90,8 +90,10 @@ class AISPayloadArmoringOutputStream(jos: java.io.OutputStream) extends OutputSt
 
   private var closed = false
 
-  class FormatInfoForAISDecode extends FormatInfo {
-    // TODO: do byteOrder and bitOrder even get used?
+  object FormatInfoForAISDecode extends FormatInfo {
+    // Q: do byteOrder and bitOrder even get used?
+    // A: yes, by decode verifying the consistency of the BitsCharset with this
+    //    as the pre-existing context.
     override def byteOrder: ByteOrder = ByteOrder.BigEndian
     override def bitOrder: BitOrder = BitOrder.MostSignificantBitFirst
     override def encodingErrorPolicy: EncodingErrorPolicy = EncodingErrorPolicy.Replace
@@ -113,7 +115,7 @@ class AISPayloadArmoringOutputStream(jos: java.io.OutputStream) extends OutputSt
     if (!closed) {
       val ba = baos.toByteArray
       using(InputSourceDataInputStream(ba)) { dis =>
-        val finfo = new FormatInfoForAISDecode()
+        val finfo = FormatInfoForAISDecode
         val cb = CharBuffer.allocate(256)
         //
         // TODO: This is not a supportable API. We want to reuse the bitsCharset features of daffodil

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/CheckDigitLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/CheckDigitLayer.scala
@@ -19,8 +19,8 @@ package org.apache.daffodil.runtime1.layers
 
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-
-import org.apache.daffodil.lib.exceptions.Assert
+import java.nio.charset.IllegalCharsetNameException
+import java.nio.charset.UnsupportedCharsetException
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.runtime1.layers.api.ChecksumLayer
 
@@ -52,19 +52,15 @@ class CheckDigitLayer
   private var params: String = _
   private var digitEncoding: String = _
 
+  setProcessingErrorException(classOf[IllegalCharsetNameException])
+  setProcessingErrorException(classOf[UnsupportedCharsetException])
+
   /**
    * Lazy so that if the digitEncoding is not a valid charset, that we get
    * a processing error at runtime, not a unrecoverable/fatal error.
    */
-  private lazy val charset =
-    try {
-      Charset.forName(digitEncoding)
-    } catch {
-      case re: RuntimeException => {
-        processingError(re)
-        Assert.impossible("prior statement ends with throw")
-      }
-    }
+  private lazy val charset = Charset.forName(digitEncoding)
+
   private lazy val isVerbose = params.toLowerCase.contains("verbose")
 
   /**

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
@@ -26,7 +26,6 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThrowsSDE
 import org.apache.daffodil.lib.schema.annotation.props.Enum
 import org.apache.daffodil.runtime1.layers.api.Layer
-import org.apache.daffodil.runtime1.layers.api.Layer.LayerThrowHandler
 
 /**
  * This layer has bombWhere and bombHow variables to enable
@@ -92,14 +91,7 @@ final class STL_BombOutLayer() extends Layer("stlBombOutLayer", "urn:STL") {
   private var bombWhere: Loc = _
   private var bombHow: Kind = _
 
-  private def lth = new LayerThrowHandler() {
-
-    /** Convert all Exception throws into Processing Errors  */
-    override def handleThrow(t: Throwable): Unit = t match {
-      case e: Exception => processingError(e)
-    }
-  }
-  setLayerThrowHandler(lth)
+  setProcessingErrorException(classOf[Exception])
 
   private def bomb(loc: Loc): Unit = {
     loc match {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
@@ -26,6 +26,7 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThrowsSDE
 import org.apache.daffodil.lib.schema.annotation.props.Enum
 import org.apache.daffodil.runtime1.layers.api.Layer
+import org.apache.daffodil.runtime1.layers.api.Layer.LayerThrowHandler
 
 /**
  * This layer has bombWhere and bombHow variables to enable
@@ -90,6 +91,15 @@ final class STL_BombOutLayer() extends Layer("stlBombOutLayer", "urn:STL") {
 
   private var bombWhere: Loc = _
   private var bombHow: Kind = _
+
+  private def lth = new LayerThrowHandler() {
+
+    /** Convert all Exception throws into Processing Errors  */
+    override def handleThrow(t: Throwable): Unit = t match {
+      case e: Exception => processingError(e)
+    }
+  }
+  setLayerThrowHandler(lth)
 
   private def bomb(loc: Loc): Unit = {
     loc match {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
@@ -99,42 +99,44 @@ class TestLayers2 {
   //
   // Throwing from each place in the API
   //
-  def handleEX(testName: String) = {
-    val h = new Handle("ThrowEX") {
-      def f(s: String) =
-        intercept[Exception] {
-          runnerB.runOneTest(testName)
-        }.asInstanceOf[Exception]
-    }
-    h(testName)
-  }
-//  @Test def testBombSetterThrowEX(): Unit = runnerB.runOneTest("testBombSetterThrowEX")
-//  @Test def testBombGetterThrowEX(): Unit = runnerB.runOneTest("testBombGetterThrowEX")
-//  @Test def testBombReadThrowEX(): Unit = runnerB.runOneTest("testBombReadThrowEX")
-//  @Test def testBombCloseInputThrowEX(): Unit = runnerB.runOneTest("testBombCloseInputThrowEX")
-//  @Test def testBombWrapInputThrowEX(): Unit = runnerB.runOneTest("testBombWrapInputThrowEX")
-//  @Test def testBombWrapOutputThrowEX(): Unit = runnerB.runOneTest("testBombWrapOutputThrowEX")
-//  @Test def testBombWriteThrowEX(): Unit = runnerB.runOneTest("testBombWriteThrowEX")
-//  @Test def testBombWriteThrowEXWithSuspension(): Unit =
-//    runnerB.runOneTest("testBombWriteThrowEXWithSuspension")
-//  @Test def testBombCloseOutputThrowEX(): Unit =
-//    runnerB.runOneTest("testBombCloseOutputThrowEX")
-//  @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
-//    runnerB.runOneTest("testBombCloseOutputThrowEXWithSuspension")
 
-  @Test def testBombSetterThrowEX(): Unit = handleEX("testBombSetterThrowEX")
-  @Test def testBombGetterThrowEX(): Unit = handleEX("testBombGetterThrowEX")
-  @Test def testBombReadThrowEX(): Unit = handleEX("testBombReadThrowEX")
-  @Test def testBombCloseInputThrowEX(): Unit = handleEX("testBombCloseInputThrowEX")
-  @Test def testBombWrapInputThrowEX(): Unit = handleEX("testBombWrapInputThrowEX")
-  @Test def testBombWrapOutputThrowEX(): Unit = handleEX("testBombWrapOutputThrowEX")
-  @Test def testBombWriteThrowEX(): Unit = handleEX("testBombWriteThrowEX")
+  @Test def testBombSetterThrowEX(): Unit = runnerB.runOneTest("testBombSetterThrowEX")
+  @Test def testBombGetterThrowEX(): Unit = runnerB.runOneTest("testBombGetterThrowEX")
+  @Test def testBombReadThrowEX(): Unit = runnerB.runOneTest("testBombReadThrowEX")
+  @Test def testBombCloseInputThrowEX(): Unit = runnerB.runOneTest("testBombCloseInputThrowEX")
+  @Test def testBombWrapInputThrowEX(): Unit = runnerB.runOneTest("testBombWrapInputThrowEX")
+  @Test def testBombWrapOutputThrowEX(): Unit = runnerB.runOneTest("testBombWrapOutputThrowEX")
+  @Test def testBombWriteThrowEX(): Unit = runnerB.runOneTest("testBombWriteThrowEX")
   @Test def testBombWriteThrowEXWithSuspension(): Unit =
-    handleEX("testBombWriteThrowEXWithSuspension")
+    runnerB.runOneTest("testBombWriteThrowEXWithSuspension")
   @Test def testBombCloseOutputThrowEX(): Unit =
-    handleEX("testBombCloseOutputThrowEX")
+    runnerB.runOneTest("testBombCloseOutputThrowEX")
   @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
-    handleEX("testBombCloseOutputThrowEXWithSuspension")
+    runnerB.runOneTest("testBombCloseOutputThrowEXWithSuspension")
+
+//  def handleEX(testName: String) = {
+//    val h = new Handle("ThrowEX") {
+//      def f(s: String) =
+//        intercept[Exception] {
+//          runnerB.runOneTest(testName)
+//        }.asInstanceOf[Exception]
+//    }
+//    h(testName)
+//  }
+//  @Test def testBombSetterThrowEX(): Unit = handleEX("testBombSetterThrowEX")
+//  @Test def testBombGetterThrowEX(): Unit = handleEX("testBombGetterThrowEX")
+//  @Test def testBombReadThrowEX(): Unit = handleEX("testBombReadThrowEX")
+//  @Test def testBombCloseInputThrowEX(): Unit = handleEX("testBombCloseInputThrowEX")
+//  @Test def testBombWrapInputThrowEX(): Unit = handleEX("testBombWrapInputThrowEX")
+//  @Test def testBombWrapOutputThrowEX(): Unit = handleEX("testBombWrapOutputThrowEX")
+//  @Test def testBombWriteThrowEX(): Unit = handleEX("testBombWriteThrowEX")
+//  @Test def testBombWriteThrowEXWithSuspension(): Unit =
+//    handleEX("testBombWriteThrowEXWithSuspension")
+//  @Test def testBombCloseOutputThrowEX(): Unit =
+//    handleEX("testBombCloseOutputThrowEX")
+//  @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
+//    handleEX("testBombCloseOutputThrowEXWithSuspension")
+
   //
   // Runtime Exception thrown from each place in the API
   //

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
@@ -114,6 +114,10 @@ class TestLayers2 {
   @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
     runnerB.runOneTest("testBombCloseOutputThrowEXWithSuspension")
 
+  //
+  // KEEP THIS STUFF - These are the tests to use if the bomb layer test rig does NOT
+  // convert all Exceptions to PEs. We might want to test it both ways.
+  //
 //  def handleEX(testName: String) = {
 //    val h = new Handle("ThrowEX") {
 //      def f(s: String) =

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
@@ -99,20 +99,42 @@ class TestLayers2 {
   //
   // Throwing from each place in the API
   //
-  @Test def testBombSetterThrowEX(): Unit = runnerB.runOneTest("testBombSetterThrowEX")
-  @Test def testBombGetterThrowEX(): Unit = runnerB.runOneTest("testBombGetterThrowEX")
-  @Test def testBombReadThrowEX(): Unit = runnerB.runOneTest("testBombReadThrowEX")
-  @Test def testBombCloseInputThrowEX(): Unit = runnerB.runOneTest("testBombCloseInputThrowEX")
-  @Test def testBombWrapInputThrowEX(): Unit = runnerB.runOneTest("testBombWrapInputThrowEX")
-  @Test def testBombWrapOutputThrowEX(): Unit = runnerB.runOneTest("testBombWrapOutputThrowEX")
-  @Test def testBombWriteThrowEX(): Unit = runnerB.runOneTest("testBombWriteThrowEX")
-  @Test def testBombWriteThrowEXWithSuspension(): Unit =
-    runnerB.runOneTest("testBombWriteThrowEXWithSuspension")
-  @Test def testBombCloseOutputThrowEX(): Unit =
-    runnerB.runOneTest("testBombCloseOutputThrowEX")
-  @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
-    runnerB.runOneTest("testBombCloseOutputThrowEXWithSuspension")
+  def handleEX(testName: String) = {
+    val h = new Handle("ThrowEX") {
+      def f(s: String) =
+        intercept[Exception] {
+          runnerB.runOneTest(testName)
+        }.asInstanceOf[Exception]
+    }
+    h(testName)
+  }
+//  @Test def testBombSetterThrowEX(): Unit = runnerB.runOneTest("testBombSetterThrowEX")
+//  @Test def testBombGetterThrowEX(): Unit = runnerB.runOneTest("testBombGetterThrowEX")
+//  @Test def testBombReadThrowEX(): Unit = runnerB.runOneTest("testBombReadThrowEX")
+//  @Test def testBombCloseInputThrowEX(): Unit = runnerB.runOneTest("testBombCloseInputThrowEX")
+//  @Test def testBombWrapInputThrowEX(): Unit = runnerB.runOneTest("testBombWrapInputThrowEX")
+//  @Test def testBombWrapOutputThrowEX(): Unit = runnerB.runOneTest("testBombWrapOutputThrowEX")
+//  @Test def testBombWriteThrowEX(): Unit = runnerB.runOneTest("testBombWriteThrowEX")
+//  @Test def testBombWriteThrowEXWithSuspension(): Unit =
+//    runnerB.runOneTest("testBombWriteThrowEXWithSuspension")
+//  @Test def testBombCloseOutputThrowEX(): Unit =
+//    runnerB.runOneTest("testBombCloseOutputThrowEX")
+//  @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
+//    runnerB.runOneTest("testBombCloseOutputThrowEXWithSuspension")
 
+  @Test def testBombSetterThrowEX(): Unit = handleEX("testBombSetterThrowEX")
+  @Test def testBombGetterThrowEX(): Unit = handleEX("testBombGetterThrowEX")
+  @Test def testBombReadThrowEX(): Unit = handleEX("testBombReadThrowEX")
+  @Test def testBombCloseInputThrowEX(): Unit = handleEX("testBombCloseInputThrowEX")
+  @Test def testBombWrapInputThrowEX(): Unit = handleEX("testBombWrapInputThrowEX")
+  @Test def testBombWrapOutputThrowEX(): Unit = handleEX("testBombWrapOutputThrowEX")
+  @Test def testBombWriteThrowEX(): Unit = handleEX("testBombWriteThrowEX")
+  @Test def testBombWriteThrowEXWithSuspension(): Unit =
+    handleEX("testBombWriteThrowEXWithSuspension")
+  @Test def testBombCloseOutputThrowEX(): Unit =
+    handleEX("testBombCloseOutputThrowEX")
+  @Test def testBombCloseOutputThrowEXWithSuspension(): Unit =
+    handleEX("testBombCloseOutputThrowEXWithSuspension")
   //
   // Runtime Exception thrown from each place in the API
   //


### PR DESCRIPTION
Add some fuzz testing around gzip layer

GZip layer converts IOExceptions to PE explicitly.

Fuzz tests show that gzip does a good job converting various bad data issues into IOException, so
really that's the only one the GzipLayer has to deal with.